### PR TITLE
chore: remove test bundle publishing step from tag and release workflow

### DIFF
--- a/.github/workflows/tag-and-release.yaml
+++ b/.github/workflows/tag-and-release.yaml
@@ -58,10 +58,6 @@ jobs:
       - name: Publish Package
         run: uds run -f tasks/publish.yaml publish-package --set FLAVOR=${{ matrix.flavor }}
 
-      - name: Publish Bundle
-        if: ${{ matrix.flavor == 'upstream' }}
-        run: uds run -f tasks/publish.yaml publish-test-bundle --set FLAVOR=${{ matrix.flavor }}
-
       - name: Debug Output
         if: ${{ always() }}
         uses: defenseunicorns/uds-common/.github/actions/debug-output@0901c37366f37fea586768c79708e14e964e714e # v0.6.1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       matrix:
         flavor: [upstream]
-        type: [install]
+        type: [install, upgrade]
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Description

Test bundle shouldn't be published so removing the publish bundle from the release workflow. Also adding back upgrade testing.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-package-trust-manager/blob/main/CONTRIBUTING.md#developer-workflow) followed
